### PR TITLE
Add pagination to DOCX documents

### DIFF
--- a/src/services/docxConverter.ts
+++ b/src/services/docxConverter.ts
@@ -1,4 +1,4 @@
-import { Document, Paragraph, TextRun, HeadingLevel, Packer, Table, TableRow, TableCell, BorderStyle, ImageRun } from 'docx';
+import { Document, Paragraph, TextRun, HeadingLevel, Packer, Table, TableRow, TableCell, BorderStyle, ImageRun, Footer, Header, PageNumber } from 'docx';
 import { marked } from 'marked';
 import type { Tokens } from 'marked';
 import { Buffer } from 'buffer';
@@ -569,7 +569,27 @@ export async function convertMarkdownToDocx(markdownContent: string): Promise<Bu
       },
       sections: [{
         properties: {},
-        children: children
+        headers: {
+          default: new Header({
+            children: [new Paragraph({ text: '' })]
+          }),
+        },
+        footers: {
+          default: new Footer({
+            children: [
+              new Paragraph({
+                alignment: 'center',
+                children: [
+                  new TextRun('Page '),
+                  PageNumber.CURRENT,
+                  new TextRun(' / '),
+                  PageNumber.TOTAL_PAGES,
+                ],
+              }),
+            ],
+          }),
+        },
+        children: children,
       }],
     });
 


### PR DESCRIPTION
## Summary
- insert footers with page numbering in `docxConverter`

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686a3419daf4832d983ba319b25b8e12